### PR TITLE
Add PHP xml extension as a dependency to allow use of utf8_encode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     "swiftmailer/swiftmailer": "@stable",
     "phalcon/incubator": "^3.0",
     "aws/aws-sdk-php": "^3.3",
-    "psr/log": "^1.0"
+    "psr/log": "^1.0",
+    "ext-xml": "^0.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.5||~6.0",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "phalcon/incubator": "^3.0",
     "aws/aws-sdk-php": "^3.3",
     "psr/log": "^1.0",
-    "ext-xml": "^0.0.0"
+    "ext-xml": "^0.0.0",
     "justblackbird/handlebars.php-helpers": "^1.2",
     "fightbulc/moment": "^1.26"
   },


### PR DESCRIPTION
Calls to utf8_[en|de]code fails if PHP xml extension is not present. This PR adds PHP xml extension as a dependency in composer.json